### PR TITLE
Only initialize losses if actually using them

### DIFF
--- a/code/config.yaml
+++ b/code/config.yaml
@@ -1148,6 +1148,7 @@ train:
     BCE_weight: 0
     Huber_weight: 0
     SmoothL1_weight: 0
+    SoftMargin_weight: 0
 
     # piq loss
     SSIMLoss_weight: 0

--- a/code/loss_calc.py
+++ b/code/loss_calc.py
@@ -67,250 +67,329 @@ class AllLoss(pl.LightningModule):
         self.automatic_optimization = False
 
         # loss functions
-        self.l1 = nn.L1Loss()
+        if cfg["train"]["L1Loss_weight"] > 0:
+            self.l1 = nn.L1Loss()
 
-        if cfg["train"]["loss_f"] == "L1Loss":
-            loss_f = torch.nn.L1Loss()
-        elif cfg["train"]["loss_f"] == "L1CosineSim":
-            loss_f = L1CosineSim(
+        if cfg["train"]["HFEN_weight"] > 0:
+            if cfg["train"]["loss_f"] == "L1Loss":
+                loss_f_hfen = torch.nn.L1Loss()
+            elif cfg["train"]["loss_f"] == "L1CosineSim":
+                loss_f_hfen = L1CosineSim(
+                    loss_lambda=cfg["train"]["loss_lambda"],
+                    reduction=cfg["train"]["reduction_L1CosineSim"],
+                )
+            self.HFENLoss = HFENLoss(
+                loss_f=loss_f_hfen,
+                kernel=cfg["train"]["kernel"],
+                kernel_size=cfg["train"]["kernel_size"],
+                sigma=cfg["train"]["sigma"],
+                norm=cfg["train"]["norm"],
+            )
+
+        if cfg["train"]["Elastic_weight"] > 0:
+            self.ElasticLoss = ElasticLoss(
+                a=cfg["train"]["a"], reduction=cfg["train"]["reduction_elastic"]
+            )
+
+        if cfg["train"]["Relative_l1_weight"] > 0:
+            self.RelativeL1 = RelativeL1(
+                eps=cfg["train"]["l1_eps"], reduction=cfg["train"]["reduction_relative"]
+            )
+        
+        if cfg["train"]["L1CosineSim_weight"] > 0:
+            self.L1CosineSim = L1CosineSim(
                 loss_lambda=cfg["train"]["loss_lambda"],
                 reduction=cfg["train"]["reduction_L1CosineSim"],
             )
 
-        self.HFENLoss = HFENLoss(
-            loss_f=loss_f,
-            kernel=cfg["train"]["kernel"],
-            kernel_size=cfg["train"]["kernel_size"],
-            sigma=cfg["train"]["sigma"],
-            norm=cfg["train"]["norm"],
-        )
-        self.ElasticLoss = ElasticLoss(
-            a=cfg["train"]["a"], reduction=cfg["train"]["reduction_elastic"]
-        )
-        self.RelativeL1 = RelativeL1(
-            eps=cfg["train"]["l1_eps"], reduction=cfg["train"]["reduction_relative"]
-        )
-        self.L1CosineSim = L1CosineSim(
-            loss_lambda=cfg["train"]["loss_lambda"],
-            reduction=cfg["train"]["reduction_L1CosineSim"],
-        )
-        self.ClipL1 = ClipL1(
-            clip_min=cfg["train"]["clip_min"], clip_max=cfg["train"]["clip_max"]
-        )
-
-        if cfg["train"]["loss_f_fft"] == "L1Loss":
-            loss_f_fft = torch.nn.L1Loss
-        elif cfg["train"]["loss_f_fft"] == "L1CosineSim":
-            loss_f_fft = L1CosineSim(
-                loss_lambda=cfg["train"]["loss_lambda"],
-                reduction=cfg["train"]["reduction_L1CosineSim"],
+        if cfg["train"]["ClipL1_weight"] > 0:
+            self.ClipL1 = ClipL1(
+                clip_min=cfg["train"]["clip_min"], clip_max=cfg["train"]["clip_max"]
             )
 
-        self.FFTloss = FFTloss(
-            loss_f=loss_f_fft, reduction=cfg["train"]["reduction_fft"]
-        )
-        self.OFLoss = OFLoss()
-        self.GPLoss = GPLoss(
-            trace=cfg["train"]["gp_trace"], spl_denorm=cfg["train"]["gp_spl_denorm"]
-        )
-        self.CPLoss = CPLoss(
-            rgb=cfg["train"]["rgb"],
-            yuv=cfg["train"]["yuv"],
-            yuvgrad=cfg["train"]["yuvgrad"],
-            trace=cfg["train"]["cp_trace"],
-            spl_denorm=cfg["train"]["cp_spl_denorm"],
-            yuv_denorm=cfg["train"]["yuv_denorm"],
-        )
-        self.StyleLoss = StyleLoss()
-        self.TVLoss = TVLoss(tv_type=cfg["train"]["tv_type"], p=cfg["train"]["p"])
-        self.Contextual_Loss = Contextual_Loss(
-            cfg["train"]["layers_weights"],
-            crop_quarter=cfg["train"]["crop_quarter"],
-            max_1d_size=cfg["train"]["max_1d_size"],
-            distance_type=cfg["train"]["distance_type"],
-            b=cfg["train"]["b"],
-            band_width=cfg["train"]["band_width"],
-            use_vgg=cfg["train"]["use_vgg"],
-            net=cfg["train"]["net_contextual"],
-            calc_type=cfg["train"]["calc_type"],
-            use_timm=cfg["train"]["use_timm"],
-            timm_model=cfg["train"]["timm_model"],
-        )
-        self.textured_loss = textured_loss()
+        if cfg["train"]["FFTLoss_weight"] > 0:
+            if cfg["train"]["loss_f_fft"] == "L1Loss":
+                loss_f_fft = torch.nn.L1Loss
+            elif cfg["train"]["loss_f_fft"] == "L1CosineSim":
+                loss_f_fft = L1CosineSim(
+                    loss_lambda=cfg["train"]["loss_lambda"],
+                    reduction=cfg["train"]["reduction_L1CosineSim"],
+                )
+            self.FFTloss = FFTloss(
+                loss_f=loss_f_fft, reduction=cfg["train"]["reduction_fft"]
+            )
 
-        self.MSELoss = torch.nn.MSELoss()
-        self.L1Loss = nn.L1Loss()
-        self.BCELogits = torch.nn.BCEWithLogitsLoss()
-        self.BCE = torch.nn.BCELoss()
-        self.FFLoss = FocalFrequencyLoss()
+        if cfg["train"]["OFLoss_weight"] > 0:
+            self.OFLoss = OFLoss()
+
+        if cfg["train"]["GPLoss_weight"] > 0:
+            self.GPLoss = GPLoss(
+                trace=cfg["train"]["gp_trace"], spl_denorm=cfg["train"]["gp_spl_denorm"]
+            )
+        if cfg["train"]["CPLoss_weight"] > 0:    
+            self.CPLoss = CPLoss(
+                rgb=cfg["train"]["rgb"],
+                yuv=cfg["train"]["yuv"],
+                yuvgrad=cfg["train"]["yuvgrad"],
+                trace=cfg["train"]["cp_trace"],
+                spl_denorm=cfg["train"]["cp_spl_denorm"],
+                yuv_denorm=cfg["train"]["yuv_denorm"],
+            )
+
+        if cfg["train"]["StyleLoss_weight"] > 0:
+            self.StyleLoss = StyleLoss()
+
+        if cfg["train"]["TVLoss_weight"] > 0:    
+            self.TVLoss = TVLoss(tv_type=cfg["train"]["tv_type"], p=cfg["train"]["p"])
+
+        if cfg["train"]["Contextual_weight"] > 0:
+            self.Contextual_Loss = Contextual_Loss(
+                cfg["train"]["layers_weights"],
+                crop_quarter=cfg["train"]["crop_quarter"],
+                max_1d_size=cfg["train"]["max_1d_size"],
+                distance_type=cfg["train"]["distance_type"],
+                b=cfg["train"]["b"],
+                band_width=cfg["train"]["band_width"],
+                use_vgg=cfg["train"]["use_vgg"],
+                net=cfg["train"]["net_contextual"],
+                calc_type=cfg["train"]["calc_type"],
+                use_timm=cfg["train"]["use_timm"],
+                timm_model=cfg["train"]["timm_model"],
+            )
+        
+        if cfg["train"]["textured_loss_weight"] > 0:
+            self.textured_loss = textured_loss()
+
+        if cfg["train"]["MSE_weight"] > 0:
+            self.MSELoss = torch.nn.MSELoss()
+
+        if cfg["train"]["L1Loss_weight"] > 0:
+            self.L1Loss = nn.L1Loss()
+
+        if cfg["train"]["BCE_weight"] > 0:
+            self.BCELogits = torch.nn.BCEWithLogitsLoss()
+            self.BCE = torch.nn.BCELoss()
+
+        if cfg["train"]["FFLoss_weight"] > 0:
+            self.FFLoss = FocalFrequencyLoss()
 
         # perceptual loss
-        from arch.networks_basic import PNetLin
+        if cfg["train"]["perceptual_weight"] > 0:
+            from arch.networks_basic import PNetLin
 
-        self.perceptual_loss = PNetLin(
-            pnet_rand=cfg["train"]["pnet_rand"],
-            pnet_tune=cfg["train"]["pnet_tune"],
-            pnet_type=cfg["train"]["pnet_type"],
-            use_dropout=cfg["train"]["use_dropout"],
-            spatial=cfg["train"]["spatial"],
-            version=cfg["train"]["version"],
-            lpips=cfg["train"]["lpips"],
-        )
-        model_path = os.path.abspath(
-            f'loss/lpips_weights/v0.1/{cfg["train"]["pnet_type"]}.pth'
-        )
-        print(f"Loading model from: {model_path}")
-        self.perceptual_loss.load_state_dict(
-            torch.load(model_path, map_location=torch.device(self.device)), strict=False
-        )
-        for param in self.perceptual_loss.parameters():
-            param.requires_grad = False
-
-        if (
-            cfg["train"]["force_fp16_perceptual"] is True
-            and cfg["train"]["perceptual_tensorrt"] is False
-        ):
-            print("Converting perceptual model to FP16")
-            self.perceptual_loss = self.perceptual_loss.half()
-
-        if (
-            cfg["train"]["force_fp16_perceptual"] is True
-            and cfg["train"]["perceptual_tensorrt"] is True
-        ):
-            print("Converting perceptual model to TensorRT (FP16)")
-            import torch_tensorrt
-
-            example_data = torch.rand(1, 3, 256, 448).half().cuda()
-            self.perceptual_loss = self.perceptual_loss.half().cuda()
-            self.perceptual_loss = torch.jit.trace(
-                self.perceptual_loss, [example_data, example_data]
+            self.perceptual_loss = PNetLin(
+                pnet_rand=cfg["train"]["pnet_rand"],
+                pnet_tune=cfg["train"]["pnet_tune"],
+                pnet_type=cfg["train"]["pnet_type"],
+                use_dropout=cfg["train"]["use_dropout"],
+                spatial=cfg["train"]["spatial"],
+                version=cfg["train"]["version"],
+                lpips=cfg["train"]["lpips"],
             )
-            self.perceptual_loss = torch_tensorrt.compile(
-                self.perceptual_loss,
-                inputs=[
-                    torch_tensorrt.Input(
-                        min_shape=(1, 3, 64, 64),
-                        opt_shape=(1, 3, 256, 448),
-                        max_shape=(1, 3, 720, 1280),
-                        dtype=torch.half,
-                    ),
-                    torch_tensorrt.Input(
-                        min_shape=(1, 3, 64, 64),
-                        opt_shape=(1, 3, 256, 448),
-                        max_shape=(1, 3, 720, 1280),
-                        dtype=torch.half,
-                    ),
-                ],
-                enabled_precisions={torch.half},
-                truncate_long_and_double=True,
+            model_path = os.path.abspath(
+                f'loss/lpips_weights/v0.1/{cfg["train"]["pnet_type"]}.pth'
             )
-            del example_data
-
-        elif (
-            cfg["train"]["force_fp16_perceptual"] is False
-            and cfg["train"]["perceptual_tensorrt"] is True
-        ):
-            print("Converting perceptual model to TensorRT")
-            import torch_tensorrt
-
-            example_data = torch.rand(1, 3, 256, 448)
-            self.perceptual_loss = torch.jit.trace(
-                self.perceptual_loss, [example_data, example_data]
+            print(f"Loading model from: {model_path}")
+            self.perceptual_loss.load_state_dict(
+                torch.load(model_path, map_location=torch.device(self.device)), strict=False
             )
-            self.perceptual_loss = torch_tensorrt.compile(
-                self.perceptual_loss,
-                inputs=[
-                    torch_tensorrt.Input(
-                        min_shape=(1, 3, 64, 64),
-                        opt_shape=(1, 3, 256, 448),
-                        max_shape=(1, 3, 720, 1280),
-                        dtype=torch.float32,
-                    ),
-                    torch_tensorrt.Input(
-                        min_shape=(1, 3, 64, 64),
-                        opt_shape=(1, 3, 256, 448),
-                        max_shape=(1, 3, 720, 1280),
-                        dtype=torch.float32,
-                    ),
-                ],
-                enabled_precisions={torch.float},
-                truncate_long_and_double=True,
+            for param in self.perceptual_loss.parameters():
+                param.requires_grad = False
+
+            if (
+                cfg["train"]["force_fp16_perceptual"] is True
+                and cfg["train"]["perceptual_tensorrt"] is False
+            ):
+                print("Converting perceptual model to FP16")
+                self.perceptual_loss = self.perceptual_loss.half()
+
+            if (
+                cfg["train"]["force_fp16_perceptual"] is True
+                and cfg["train"]["perceptual_tensorrt"] is True
+            ):
+                print("Converting perceptual model to TensorRT (FP16)")
+                import torch_tensorrt
+
+                example_data = torch.rand(1, 3, 256, 448).half().cuda()
+                self.perceptual_loss = self.perceptual_loss.half().cuda()
+                self.perceptual_loss = torch.jit.trace(
+                    self.perceptual_loss, [example_data, example_data]
+                )
+                self.perceptual_loss = torch_tensorrt.compile(
+                    self.perceptual_loss,
+                    inputs=[
+                        torch_tensorrt.Input(
+                            min_shape=(1, 3, 64, 64),
+                            opt_shape=(1, 3, 256, 448),
+                            max_shape=(1, 3, 720, 1280),
+                            dtype=torch.half,
+                        ),
+                        torch_tensorrt.Input(
+                            min_shape=(1, 3, 64, 64),
+                            opt_shape=(1, 3, 256, 448),
+                            max_shape=(1, 3, 720, 1280),
+                            dtype=torch.half,
+                        ),
+                    ],
+                    enabled_precisions={torch.half},
+                    truncate_long_and_double=True,
+                )
+                del example_data
+
+            elif (
+                cfg["train"]["force_fp16_perceptual"] is False
+                and cfg["train"]["perceptual_tensorrt"] is True
+            ):
+                print("Converting perceptual model to TensorRT")
+                import torch_tensorrt
+
+                example_data = torch.rand(1, 3, 256, 448)
+                self.perceptual_loss = torch.jit.trace(
+                    self.perceptual_loss, [example_data, example_data]
+                )
+                self.perceptual_loss = torch_tensorrt.compile(
+                    self.perceptual_loss,
+                    inputs=[
+                        torch_tensorrt.Input(
+                            min_shape=(1, 3, 64, 64),
+                            opt_shape=(1, 3, 256, 448),
+                            max_shape=(1, 3, 720, 1280),
+                            dtype=torch.float32,
+                        ),
+                        torch_tensorrt.Input(
+                            min_shape=(1, 3, 64, 64),
+                            opt_shape=(1, 3, 256, 448),
+                            max_shape=(1, 3, 720, 1280),
+                            dtype=torch.float32,
+                        ),
+                    ],
+                    enabled_precisions={torch.float},
+                    truncate_long_and_double=True,
+                )
+                del example_data
+
+        if cfg["network_G"]["netG"] == "CSA":
+            self.ConsistencyLoss = ConsistencyLoss()
+
+        if cfg["train"]["Canny_weight"] > 0:
+            self.CannyLoss = CannyLoss(
+                threshold=cfg["train"]["canny_threshold"],
+                blurred_img_weight=cfg["train"]["canny_blurred_img_weight"],
+                grad_mag_weight=cfg["train"]["canny_grad_mag_weight"],
+                grad_orientation_weight=cfg["train"]["canny_grad_mag_weight"],
+                thin_edges_weight=cfg["train"]["canny_thin_edges_weight"],
+                thresholded_weight=cfg["train"]["canny_thresholded_weight"],
+                early_threshold=cfg["train"]["canny_early_threshold"],
             )
-            del example_data
 
-        self.ConsistencyLoss = ConsistencyLoss()
+        if cfg["train"]["KullbackHistogramLoss_weight"] > 0:
+            self.KullbackHistogramLoss = KullbackHistogramLoss()
+        
+        if cfg["train"]["SalientRegionLoss_weight"] > 0:
+            self.SalientRegionLoss = SalientRegionLoss()
+        
+        if cfg["train"]["glcmLoss_weight"] > 0:
+            self.glcmLoss = glcmLoss()
 
-        self.CannyLoss = CannyLoss(
-            threshold=cfg["train"]["canny_threshold"],
-            blurred_img_weight=cfg["train"]["canny_blurred_img_weight"],
-            grad_mag_weight=cfg["train"]["canny_grad_mag_weight"],
-            grad_orientation_weight=cfg["train"]["canny_grad_mag_weight"],
-            thin_edges_weight=cfg["train"]["canny_thin_edges_weight"],
-            thresholded_weight=cfg["train"]["canny_thresholded_weight"],
-            early_threshold=cfg["train"]["canny_early_threshold"],
-        )
+        if cfg["train"]["GradientDomainLoss_weight"] > 0:
+            self.GradientDomainLoss = GradientDomainLoss()
 
-        self.KullbackHistogramLoss = KullbackHistogramLoss()
-        self.SalientRegionLoss = SalientRegionLoss()
-        self.glcmLoss = glcmLoss()
-        self.GradientDomainLoss = GradientDomainLoss()
-        self.SobelLoss = SobelLoss()
-        self.ColorHarmonyLoss = ColorHarmonyLoss()
-        self.VIT_FeatureLoss = VIT_FeatureLoss()
-        self.VIT_MMD_FeatureLoss = VIT_MMD_FeatureLoss()
-        self.TIMM_FeatureLoss = TIMM_FeatureLoss(
-            model_arch=cfg["train"]["TIMM_FeatureLoss_arch"],
-            resolution=cfg["train"]["TIMM_FeatureLoss_resolution"],
-            fp16=cfg["train"]["TIMM_FeatureLoss_fp16"],
-            criterion=cfg["train"]["TIMM_FeatureLoss_criterion"],
-            normalize=cfg["train"]["TIMM_FeatureLoss_normalize"],
-            last_feature=cfg["train"]["TIMM_FeatureLoss_last_feature"],
-        )
+        if cfg["train"]["SobelLoss_weight"] > 0:
+            self.SobelLoss = SobelLoss()
 
-        self.LaplacianLoss = LaplacianLoss()
-        self.SobelLossV2 = SobelLossV2()
+        if cfg["train"]["ColorHarmonyLoss_weight"] > 0:
+            self.ColorHarmonyLoss = ColorHarmonyLoss()
 
-        from arch.hrf_perceptual import ResNetPL
+        if cfg["train"]["VIT_FeatureLoss_weight"] > 0:
+            self.VIT_FeatureLoss = VIT_FeatureLoss()
 
-        self.hrf_perceptual_loss = ResNetPL()
-        for param in self.hrf_perceptual_loss.parameters():
-            param.requires_grad = False
+        if cfg["train"]["VIT_MMD_FeatureLoss_weight"] > 0:
+            self.VIT_MMD_FeatureLoss = VIT_MMD_FeatureLoss()
 
-        if cfg["train"]["force_fp16_hrf"] is True:
-            self.hrf_perceptual_loss = self.hrf_perceptual_loss.half()
+        if cfg["train"]["TIMM_FeatureLoss_weight"] > 0:
+            self.TIMM_FeatureLoss = TIMM_FeatureLoss(
+                model_arch=cfg["train"]["TIMM_FeatureLoss_arch"],
+                resolution=cfg["train"]["TIMM_FeatureLoss_resolution"],
+                fp16=cfg["train"]["TIMM_FeatureLoss_fp16"],
+                criterion=cfg["train"]["TIMM_FeatureLoss_criterion"],
+                normalize=cfg["train"]["TIMM_FeatureLoss_normalize"],
+                last_feature=cfg["train"]["TIMM_FeatureLoss_last_feature"],
+            )
 
-        self.YUVColorLoss = YUVColorLoss()
-        self.XYZColorLoss = XYZColorLoss()
+        if cfg["train"]["LaplacianLoss_weight"] > 0:
+            self.LaplacianLoss = LaplacianLoss()
 
-        self.FrobeniusNormLoss = FrobeniusNormLoss()
-        self.GradientLoss = GradientLoss()
-        self.MultiscalePixelLoss = MultiscalePixelLoss()
-        self.SPLoss = SPLoss()
+        if cfg["train"]["SobelLossV2_weight"] > 0:
+            self.SobelLossV2 = SobelLossV2()
+
+        if cfg["train"]["hrf_perceptual_weight"] > 0:
+            from arch.hrf_perceptual import ResNetPL
+
+            self.hrf_perceptual_loss = ResNetPL()
+            for param in self.hrf_perceptual_loss.parameters():
+                param.requires_grad = False
+
+            if cfg["train"]["force_fp16_hrf"] is True:
+                self.hrf_perceptual_loss = self.hrf_perceptual_loss.half()
+
+        if cfg["train"]["YUVColorLoss_weight"] > 0:
+            self.YUVColorLoss = YUVColorLoss()
+        if cfg["train"]["XYZColorLoss_weight"] > 0:
+            self.XYZColorLoss = XYZColorLoss()
+
+        if cfg["train"]["FrobeniusNormLoss_weight"] > 0:
+            self.FrobeniusNormLoss = FrobeniusNormLoss()
+        if cfg["train"]["GradientLoss_weight"] > 0:
+            self.GradientLoss = GradientLoss()
+        if cfg["train"]["MultiscalePixelLoss_weight"] > 0:
+            self.MultiscalePixelLoss = MultiscalePixelLoss()
+        if cfg["train"]["SPLoss_weight"] > 0:
+            self.SPLoss = SPLoss()
 
         # pytorch loss
-        self.HuberLoss = nn.HuberLoss()
-        self.SmoothL1Loss = nn.SmoothL1Loss()
-        self.SoftMarginLoss = nn.SoftMarginLoss()
+        if cfg["train"]["Huber_weight"] > 0:
+            self.HuberLoss = nn.HuberLoss()
+        if cfg["train"]["SmoothL1_weight"] > 0:
+            self.SmoothL1Loss = nn.SmoothL1Loss()
+        if cfg["train"]["SoftMargin_weight"] > 0:
+            self.SoftMarginLoss = nn.SoftMarginLoss()
 
-        self.LapLoss = LapLoss()
+        if cfg["train"]["Lap_weight"] > 0:
+            self.LapLoss = LapLoss()
 
         # piq loss
-        self.SSIMLoss = SSIMLoss()
-        self.MultiScaleSSIMLoss = MultiScaleSSIMLoss()
-        self.VIFLoss = VIFLoss()
-        self.FSIMLoss = FSIMLoss()
-        self.GMSDLoss = GMSDLoss()
-        self.MultiScaleGMSDLoss = MultiScaleGMSDLoss()
-        self.VSILoss = VSILoss()
-        self.HaarPSILoss = HaarPSILoss()
-        self.MDSILoss = MDSILoss()
-        self.BRISQUELoss = BRISQUELoss()
-        self.PieAPP = PieAPP(enable_grad=True)
-        self.DISTS = DISTS()
-        self.IS = IS()
-        self.FID = FID()
-        self.KID = KID()
-        self.PR = PR()
+        if cfg["train"]["SSIMLoss_weight"] > 0:
+            self.SSIMLoss = SSIMLoss()
+        if cfg["train"]["MultiScaleSSIMLoss_weight"] > 0:
+            self.MultiScaleSSIMLoss = MultiScaleSSIMLoss()
+        if cfg["train"]["VIFLoss_weight"] > 0:
+            self.VIFLoss = VIFLoss()
+        if cfg["train"]["FSIMLoss_weight"] > 0:
+            self.FSIMLoss = FSIMLoss()
+        if cfg["train"]["GMSDLoss_weight"] > 0:
+            self.GMSDLoss = GMSDLoss()
+        if cfg["train"]["MultiScaleGMSDLoss_weight"] > 0:
+            self.MultiScaleGMSDLoss = MultiScaleGMSDLoss()
+        if cfg["train"]["VSILoss_weight"] > 0:
+            self.VSILoss = VSILoss()
+        if cfg["train"]["HaarPSILoss_weight"] > 0:
+            self.HaarPSILoss = HaarPSILoss()
+        if cfg["train"]["MDSILoss_weight"] > 0:
+            self.MDSILoss = MDSILoss()
+        if cfg["train"]["BRISQUELoss_weight"] > 0:    
+            self.BRISQUELoss = BRISQUELoss()
+        if cfg["train"]["PieAPP_weight"] > 0:
+            self.PieAPP = PieAPP(enable_grad=True)
+        if cfg["train"]["DISTS_weight"] > 0:
+            self.DISTS = DISTS()
+        if cfg["train"]["IS_weight"] > 0:
+            self.IS = IS()
+        if cfg["train"]["FID_weight"] > 0:
+            self.FID = FID()
+        if cfg["train"]["KID_weight"] > 0:
+            self.KID = KID()
+        if cfg["train"]["PR_weight"] > 0:
+            self.PR = PR()
 
         if cfg["network_G"]["netG"] == "rife":
             from loss.loss import SOBEL
@@ -573,6 +652,16 @@ class AllLoss(pl.LightningModule):
             if self.cfg["logging"]:
                 writer.add_scalar(
                     "loss/SmoothL1" + log_suffix, SmoothL1_forward, global_step
+                )
+
+        if self.cfg["train"]["SoftMargin_weight"] > 0:
+            SoftMargin_forward = self.cfg["train"]["SoftMargin_weight"] * self.SoftMarginLoss(
+                out, hr_image
+            )
+            total_loss += SmoothL1_forward
+            if self.cfg["logging"]:
+                writer.add_scalar(
+                    "loss/SoftMargin" + log_suffix, SoftMargin_forward, global_step
                 )
 
         if self.cfg["train"]["Lap_weight"] > 0:


### PR DESCRIPTION
I noticed when I started training ESRGAN using this, that the checkpoints were gigantic (almost 3 gigabytes) and it also downloaded a bunch of models and extra stuff for losses I wasn't using. Upon further investigation, both of these were because it was still initializing the losses in the AllLoss class regardless of if I had them configured to use.

This PR makes it only initialize the loss classes if the weight is > 0. 

This results in checkpoints of only 732mb (2GB less) as well as less vram usage (though vram usage slowly climbs back up during training).

I also noticed while doing this that SoftMarginLoss was missing from the config, so I added that as well.